### PR TITLE
API does not offer the possibility to change timezone when parsing time...

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -411,6 +411,7 @@ func (c *Canal) prepareSyncer() error {
 		ParseTime:            c.cfg.ParseTime,
 		SemiSyncEnabled:      c.cfg.SemiSyncEnabled,
 		MaxReconnectAttempts: c.cfg.MaxReconnectAttempts,
+		TimestampStringLocation: c.cfg.TimestampStringLocation,
 	}
 
 	if strings.Contains(c.cfg.Addr, "/") {

--- a/canal/config.go
+++ b/canal/config.go
@@ -68,6 +68,8 @@ type Config struct {
 	UseDecimal bool `toml:"use_decimal"`
 	ParseTime  bool `toml:"parse_time"`
 
+	TimestampStringLocation *time.Location
+
 	// SemiSyncEnabled enables semi-sync or not.
 	SemiSyncEnabled bool `toml:"semi_sync_enabled"`
 


### PR DESCRIPTION
... it's better to default to UTC